### PR TITLE
Add RGB support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,6 @@
       <groupId>ome</groupId>
       <artifactId>formats-bsd</artifactId>
       <version>${bio-formats.version}</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>ome</groupId>

--- a/src/main/java/it/crs4/features/BioImgFactory.java
+++ b/src/main/java/it/crs4/features/BioImgFactory.java
@@ -27,13 +27,13 @@ import java.io.IOException;
 import java.io.File;
 
 import loci.formats.IFormatReader;
+import loci.formats.ChannelSeparator;
 import loci.formats.FormatException;
 
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.file.DataFileWriter;
 
 
-// FIXME: maybe it's better to split RGB channels
 public class BioImgFactory {
 
   private static final String DEFAULT_ORDER = "XYZCT";
@@ -49,6 +49,7 @@ public class BioImgFactory {
   protected List<Integer> shape;
 
   public BioImgFactory(IFormatReader reader) {
+    reader = new ChannelSeparator(reader);
     this.reader = reader;
     dimOrder = reader.getDimensionOrder();
     if (dimOrder.length() != N_DIM) {

--- a/src/main/java/it/crs4/features/BioImgFactory.java
+++ b/src/main/java/it/crs4/features/BioImgFactory.java
@@ -33,6 +33,7 @@ import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.file.DataFileWriter;
 
 
+// FIXME: maybe it's better to split RGB channels
 public class BioImgFactory {
 
   private static final String DEFAULT_ORDER = "XYZCT";
@@ -66,7 +67,7 @@ public class BioImgFactory {
     s[dimIdx[0]] = reader.getSizeX();
     s[dimIdx[1]] = reader.getSizeY();
     s[dimIdx[2]] = reader.getSizeZ();
-    s[dimIdx[3]] = reader.getSizeC();
+    s[dimIdx[3]] = reader.getEffectiveSizeC();
     s[dimIdx[4]] = reader.getSizeT();
     shape = Arrays.asList(s);
   }

--- a/src/main/java/it/crs4/features/ImageToAvro.java
+++ b/src/main/java/it/crs4/features/ImageToAvro.java
@@ -45,12 +45,6 @@ public final class ImageToAvro {
     reader.setId(fn);
     LOGGER.info("Reading from {}", fn);
     int seriesCount = reader.getSeriesCount();
-    if (reader.isRGB()) {
-      throw new RuntimeException("RGB img not supported");
-    }
-    if (reader.isInterleaved()) {
-      throw new RuntimeException("Interleaving not supported");
-    }
     BioImgFactory factory = new BioImgFactory(reader);
 
     // FIXME: add support for XY slicing

--- a/src/test/java/it/crs4/features/BioImgFactoryTest.java
+++ b/src/test/java/it/crs4/features/BioImgFactoryTest.java
@@ -64,7 +64,7 @@ public class BioImgFactoryTest {
   private static final int SIZE_Z = 5;
   private static final int EFF_SIZE_C = 1;
   private static final int SIZE_T = 2;
-  private static final int SPP = 1;  // Samples per pixel (e.g., 3 for RGB)
+  private static final int SPP = 3;  // Samples per pixel (e.g., 3 for RGB)
 
   // dependent
   private static final int PLANE_SIZE =


### PR DESCRIPTION
Adds support for RGB images by wrapping the reader with `ChannelSeparator`. This means that Avro records always have split channels.