### PR TITLE
Add a tiling option to calc_features

### DIFF
--- a/dev_tools/map_feature_names
+++ b/dev_tools/map_feature_names
@@ -28,6 +28,10 @@ protocol FeatureSet {
   record Signatures {
     string version;
     string plane_tag;
+    int w;
+    int h;
+    int x;
+    int y;
 """
 AVRO_IDL_FOOTER = """\
   }
@@ -84,10 +88,10 @@ def generate_avro(names_map):
 
 
 def main():
-    img = get_random_img(48, 48)
+    img = get_random_img(8, 8)
     print "computing features for random img"
-    short_names = calc_features(img, "short", long=False).feature_names
-    long_names = calc_features(img, "long", long=True).feature_names
+    short_names = calc_features(img, "short", long=False).next().feature_names
+    long_names = calc_features(img, "long", long=True).next().feature_names
     N_SHORT, N_LONG = len(short_names), len(long_names)
     short_names, long_names = set(short_names), set(long_names)
     assert len(short_names) == N_SHORT and len(long_names) == N_LONG

--- a/docs/tiles.svg
+++ b/docs/tiles.svg
@@ -1,0 +1,618 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="234.85555"
+   height="176.26669"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="tiles.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="88.393569"
+     inkscape:cy="90.528125"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1301"
+     inkscape:window-height="744"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     fit-margin-top="0.1"
+     fit-margin-left="0.1"
+     fit-margin-bottom="0.1"
+     fit-margin-right="0.1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-87.633269,-90.446959)">
+    <rect
+       style="fill:none;stroke:#323232;stroke-width:0.30000001;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect2985"
+       width="29.294424"
+       height="29.294424"
+       x="87.88327"
+       y="90.69696"
+       ry="0"
+       inkscape:tile-cx="102.53048"
+       inkscape:tile-cy="105.34417"
+       inkscape:tile-w="29.294424"
+       inkscape:tile-h="29.294424"
+       inkscape:tile-x0="87.88327"
+       inkscape:tile-y0="90.69696" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(0,29.294424)"
+       id="use3853"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(0,58.588848)"
+       id="use3855"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(0,87.883272)"
+       id="use3857"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(0,117.1777)"
+       id="use3859"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(0,146.47212)"
+       id="use3861"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(29.294424,0)"
+       id="use3863"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(29.294424,29.294424)"
+       id="use3865"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(29.294424,58.588848)"
+       id="use3867"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(29.294424,87.883272)"
+       id="use3869"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(29.294424,117.1777)"
+       id="use3871"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(29.294424,146.47212)"
+       id="use3873"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(58.588848,0)"
+       id="use3875"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(58.588848,29.294424)"
+       id="use3877"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(58.588848,58.588848)"
+       id="use3879"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(58.588848,87.883272)"
+       id="use3881"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(58.588848,117.1777)"
+       id="use3883"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(58.588848,146.47212)"
+       id="use3885"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(87.883272,0)"
+       id="use3887"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(87.883272,29.294424)"
+       id="use3889"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(87.883272,58.588848)"
+       id="use3891"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(87.883272,87.883272)"
+       id="use3893"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(87.883272,117.1777)"
+       id="use3895"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(87.883272,146.47212)"
+       id="use3897"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(117.1777,0)"
+       id="use3899"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(117.1777,29.294424)"
+       id="use3901"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(117.1777,58.588848)"
+       id="use3903"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(117.1777,87.883272)"
+       id="use3905"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(117.1777,117.1777)"
+       id="use3907"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(117.1777,146.47212)"
+       id="use3909"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(146.47212,0)"
+       id="use3911"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(146.47212,29.294424)"
+       id="use3913"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(146.47212,58.588848)"
+       id="use3915"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(146.47212,87.883272)"
+       id="use3917"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(146.47212,117.1777)"
+       id="use3919"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(146.47212,146.47212)"
+       id="use3921"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(175.76654,0)"
+       id="use3923"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(175.76654,29.294424)"
+       id="use3925"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(175.76654,58.588848)"
+       id="use3927"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(175.76654,87.883272)"
+       id="use3929"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(175.76654,117.1777)"
+       id="use3931"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(175.76654,146.47212)"
+       id="use3933"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(205.06097,0)"
+       id="use3935"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(205.06097,29.294424)"
+       id="use3937"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(205.06097,58.588848)"
+       id="use3939"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(205.06097,87.883272)"
+       id="use3941"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(205.06097,117.1777)"
+       id="use3943"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       x="0"
+       y="0"
+       inkscape:tiled-clone-of="#rect2985"
+       xlink:href="#rect2985"
+       transform="translate(205.06097,146.47212)"
+       id="use3945"
+       width="744.09448"
+       height="1052.3622" />
+    <rect
+       style="fill:#000000;fill-opacity:0.27397263;stroke:#000000;stroke-width:1;stroke-opacity:1"
+       id="rect3969"
+       width="87.182999"
+       height="116.478"
+       x="88.233269"
+       y="91.046959"
+       ry="7.4836888" />
+    <rect
+       style="fill:#000000;fill-opacity:0.27397263;stroke:#000000;stroke-width:1;stroke-opacity:1"
+       id="rect3969-8"
+       width="87.182999"
+       height="116.478"
+       x="176.11655"
+       y="91.046959"
+       ry="7.4836888" />
+    <rect
+       style="fill:#000000;fill-opacity:0.27397263;stroke:#000000;stroke-width:1;stroke-opacity:1"
+       id="rect3969-8-9"
+       width="57.889"
+       height="116.478"
+       x="263.99982"
+       y="91.046959"
+       ry="7.4836888" />
+    <rect
+       style="fill:#000000;fill-opacity:0.27397263;stroke:#000000;stroke-width:1;stroke-opacity:1"
+       id="rect3969-4"
+       width="87.182999"
+       height="57.889"
+       x="88.233269"
+       y="208.22466"
+       ry="3.719357" />
+    <rect
+       style="fill:#000000;fill-opacity:0.27397263;stroke:#000000;stroke-width:1;stroke-opacity:1"
+       id="rect3969-4-4"
+       width="87.182999"
+       height="57.889"
+       x="176.11682"
+       y="208.2245"
+       ry="3.719357" />
+    <rect
+       style="fill:#000000;fill-opacity:0.27397263;stroke:#000000;stroke-width:1;stroke-opacity:1"
+       id="rect3969-4-4-2"
+       width="57.889"
+       height="57.889"
+       x="263.99966"
+       y="208.2245"
+       ry="3.719357" />
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="209.2471"
+       y="160.95001"
+       id="text4082"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4084"
+         x="209.2471"
+         y="160.95001"
+         style="font-size:32px">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="121.65289"
+       y="160.93439"
+       id="text4082-7"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         x="121.65289"
+         y="160.93439"
+         id="tspan4107"
+         style="font-size:32px">0</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="283.19431"
+       y="161.16095"
+       id="text4082-2"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4084-1"
+         x="283.19431"
+         y="161.16095"
+         style="font-size:32px">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="121.70758"
+       y="248.81744"
+       id="text4082-2-1"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4084-1-0"
+         x="121.70758"
+         y="248.81744"
+         style="font-size:32px">3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="209.64581"
+       y="248.83307"
+       id="text4082-2-1-3"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4084-1-0-9"
+         x="209.64581"
+         y="248.83307"
+         style="font-size:32px">4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="282.92853"
+       y="248.60651"
+       id="text4082-2-1-3-5"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4084-1-0-9-4"
+         x="282.92853"
+         y="248.60651"
+         style="font-size:32px">5</tspan></text>
+  </g>
+</svg>

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -33,6 +33,7 @@ class Mapper(api.Mapper):
         p = BioImgPlane(ctx.value)
         pixels = p.get_xy()
         plane_tag = '%s-z%04d-c%04d-t%04d' % (p.name, p.z, p.c, p.t)
+        # TODO: support tiling
         out_rec = to_avro(calc_features(pixels, plane_tag))
         ctx.emit(None, out_rec)
 

--- a/scripts/local_features
+++ b/scripts/local_features
@@ -50,6 +50,10 @@ def make_parser():
     parser.add_argument('-o', '--out-dir', metavar='DIR', default=os.getcwd())
     parser.add_argument('-l', '--long', action='store_true',
                         help='extract WND-CHARM\'s "long" features set')
+    parser.add_argument('-W', '--width', type=int, metavar="INT",
+                        help='tile width (default = image width)')
+    parser.add_argument('-H', '--height', type=int, metavar="INT",
+                        help='tile height (default = image height)')
     parser.add_argument('-v', '--verbose', action='store_true')
     return parser
 
@@ -76,9 +80,10 @@ def main(argv):
                 plane_tag = '%s-z%04d-c%04d-t%04d' % (p.name, p.z, p.c, p.t)
                 if args.verbose:
                     print '  processing %s' % plane_tag
-                features = calc_features(pixels, plane_tag, long=args.long)
-                out_rec = to_avro(features)
-                writer.write(out_rec)
+                for fv in calc_features(pixels, plane_tag, long=args.long,
+                                        w=args.width, h=args.height):
+                    out_rec = to_avro(fv)
+                    writer.write(out_rec)
         writer.close()
 
 

--- a/src/main/avro/featureset.avdl
+++ b/src/main/avro/featureset.avdl
@@ -6,6 +6,10 @@ protocol FeatureSet {
   record Signatures {
     string version;
     string plane_tag;
+    int w;
+    int h;
+    int x;
+    int y;
     array<double> chebyshev_coefficients;
     array<double> chebyshev_coefficients_chebyshev;
     array<double> chebyshev_coefficients_edge;

--- a/test/test_feature_calc.py
+++ b/test/test_feature_calc.py
@@ -34,51 +34,82 @@ import pyfeatures.pyavroc_emu as pyavroc_emu
 from pyfeatures.schema import Signatures
 
 
-SHAPE = (8, 8)
+W, H = 8, 6
 DTYPE = np.uint8
 
 
-def make_random_data(filename=None):
+def make_random_data():
     info = np.iinfo(DTYPE)
     a = np.random.randint(
-        info.min, info.max, SHAPE[0] * SHAPE[1]
-    ).astype(DTYPE).reshape(SHAPE)
-    if filename is not None:
-        with closing(TIFF.open(filename, mode="w")) as fo:
-            fo.write_image(a)
+        info.min, info.max, W * H
+    ).astype(DTYPE).reshape((H, W))
     return a
+
+
+def dump_to_tiff(ndarray, filename):
+    with closing(TIFF.open(filename, mode="w")) as fo:
+        fo.write_image(ndarray)
 
 
 class TestFeatureCalc(unittest.TestCase):
 
     def setUp(self):
         self.wd = tempfile.mkdtemp(prefix="pyfeatures_")
-        self.fn = os.path.join(self.wd, "img.tiff")
-        self.a = make_random_data(filename=self.fn)
         self.plane_tag = "img_0-z0000-c0000-t0000"
 
     def tearDown(self):
         shutil.rmtree(self.wd)
 
-    def runTest(self):
+    def test_no_tiling(self):
+        a = make_random_data()
         for long in False, True:
-            sigs = calc_features(self.a, self.plane_tag, long=long)
-            exp_sigs = FeatureVector(
-                source_filepath=self.fn, long=long
-            ).GenerateFeatures(write_to_disk=False)
-            for name in "feature_names", "values", "feature_set_version":
-                self.assertEquals(getattr(sigs, name), getattr(exp_sigs, name))
+            all_sigs = list(calc_features(a, self.plane_tag, long=long))
+            self.assertEqual(len(all_sigs), 1)
+            sigs = all_sigs[0]
+            self.assertEqual((sigs.x, sigs.y, sigs.w, sigs.h), (0, 0, W, H))
+            exp_sigs = self.__get_exp_features(a, long=long)
+            self.assertFeaturesEqual(sigs, exp_sigs)
+
+    def test_tiling(self):
+        a = make_random_data()
+        w, h = 3, 4
+        s = list(calc_features(a, self.plane_tag, w=w, h=h))
+        self.assertEqual(len(s), 6)
+        self.assertEqual((s[0].x, s[0].y, s[0].w, s[0].h), (0, 0, 3, 4))
+        self.assertFeaturesEqual(s[0], self.__get_exp_features(a[:4, :3]))
+        self.assertEqual((s[1].x, s[1].y, s[1].w, s[1].h), (3, 0, 3, 4))
+        self.assertFeaturesEqual(s[1], self.__get_exp_features(a[:4, 3:6]))
+        self.assertEqual((s[2].x, s[2].y, s[2].w, s[2].h), (6, 0, 2, 4))
+        self.assertFeaturesEqual(s[2], self.__get_exp_features(a[:4, 6:]))
+        self.assertEqual((s[3].x, s[3].y, s[3].w, s[3].h), (0, 4, 3, 2))
+        self.assertFeaturesEqual(s[3], self.__get_exp_features(a[4:, :3]))
+        self.assertEqual((s[4].x, s[4].y, s[4].w, s[4].h), (3, 4, 3, 2))
+        self.assertFeaturesEqual(s[4], self.__get_exp_features(a[4:, 3:6]))
+        self.assertEqual((s[5].x, s[5].y, s[5].w, s[5].h), (6, 4, 2, 2))
+        self.assertFeaturesEqual(s[5], self.__get_exp_features(a[4:, 6:]))
+
+    def assertFeaturesEqual(self, fv1, fv2):
+        for name in "feature_names", "values", "feature_set_version":
+            self.assertEquals(getattr(fv1, name), getattr(fv2, name))
+
+    def __get_exp_features(self, a, long=False):
+        fn = os.path.join(self.wd, "img.tiff")
+        dump_to_tiff(a, fn)
+        fv = FeatureVector(source_filepath=fn, long=long)
+        return fv.GenerateFeatures(write_to_disk=False)
 
 
 class TestToAvro(unittest.TestCase):
 
     def setUp(self):
-        self.a = make_random_data()
         self.plane_tag = "img_0-z0000-c0000-t0000"
 
-    def runTest(self):
+    def test_no_tiling(self):
+        a = make_random_data()
         for long in False, True:
-            sigs = calc_features(self.a, self.plane_tag, long=long)
+            all_sigs = list(calc_features(a, self.plane_tag, long=long))
+            self.assertEqual(len(all_sigs), 1)
+            sigs = all_sigs[0]
             rec = to_avro(sigs)
             try:
                 pyavroc_emu.AvroSerializer(Signatures).serialize(rec)
@@ -86,6 +117,8 @@ class TestToAvro(unittest.TestCase):
                 self.fail("Could not serialize record: %s" % e)
             self.assertEquals(rec["version"], sigs.feature_set_version)
             self.assertEquals(rec["plane_tag"], self.plane_tag)
+            self.assertEquals((rec["x"], rec["y"]), (0, 0))
+            self.assertEquals((rec["h"], rec["w"]), a.shape)
             fmap = dict(izip(sigs.feature_names, sigs.values))
             for fname, (vname, idx) in FEATURE_NAMES.iteritems():
                 v = fmap.get(fname)

--- a/test/test_pyavroc_emu.py
+++ b/test/test_pyavroc_emu.py
@@ -40,6 +40,7 @@ class Base(unittest.TestCase):
         signatures = {
             "version": "3.2",
             "plane_tag": "img_0-z0000-c0000-t0000",
+            "x": 0, "y": 0, "w": 400, "h": 300,
         }
         for vname, idx in FEATURE_NAMES.itervalues():
             signatures.setdefault(vname, []).append(float(idx))


### PR DESCRIPTION
Allows to compute features on rectangular sub-regions of the given image. For now, we have a minimal implementation where:

 * the user specifies tile width and height
 * `calc_features` generates non-overlapping tiles starting from `[0, 0]` and yields a separate feature vector for each tile
 * "incomplete" tiles at the right and bottom edges are kept and treated like the other ones (features are computed and returned)

The following image illustrates what happens with 3 x 4 tiles on an 8 x 6 image:

![tiling](https://cloud.githubusercontent.com/assets/1183171/13741471/65899360-e9ce-11e5-82fb-85969e194948.png)

Of course, the user has a better choice here (4 x 3). The above example shows what happens in a worst-case scenario.