### PR TITLE
Add SZCT indices to output record

### DIFF
--- a/dev_tools/map_feature_names
+++ b/dev_tools/map_feature_names
@@ -27,11 +27,10 @@ protocol FeatureSet {
 
   record Signatures {
     string version;
-    string plane_tag;
-    int w;
-    int h;
-    int x;
-    int y;
+    string name;
+    string img_path;
+    int series, z, c, t;
+    int x, y, w, h;
 """
 AVRO_IDL_FOOTER = """\
   }

--- a/pyfeatures/bioimg.py
+++ b/pyfeatures/bioimg.py
@@ -78,8 +78,8 @@ class BioImgPlane(object):
         if self.i_x < self.i_y:
             # map y to rows and x to columns so that xy slices are img planes
             self.__swap_xy(r)
-        self.name = r['name']
-        self.dimension_order = r['dimension_order']
+        for k in 'name', 'img_path', 'dimension_order', 'series':
+            setattr(self, k, r[k])
         self.__check_dim_order()
         self.pixel_data = ArraySlice(r['pixel_data'])
         self.__check_is_plane()

--- a/pyfeatures/feature_calc.py
+++ b/pyfeatures/feature_calc.py
@@ -16,7 +16,7 @@ def get_image_matrix(img_array):
     return image_matrix
 
 
-def calc_features(img_array, plane_tag, long=False, w=None, h=None):
+def calc_features(img_array, tag, long=False, w=None, h=None):
     if len(img_array.shape) != 2:
         raise ValueError("array must be two-dimensional")
     H, W = img_array.shape
@@ -29,7 +29,7 @@ def calc_features(img_array, plane_tag, long=False, w=None, h=None):
     for i in xrange(0, H, h):
         for j in xrange(0, W, w):
             tile = img_array[i: i + h, j: j + w]
-            signatures = FeatureVector(basename=plane_tag, long=long)
+            signatures = FeatureVector(basename=tag, long=long)
             signatures.original_px_plane = get_image_matrix(tile)
             signatures.GenerateFeatures(write_to_disk=False)
             signatures.x, signatures.y = j, i
@@ -45,7 +45,7 @@ def to_avro(signatures):
     for vname, tuples in rec.iteritems():
         rec[vname] = [_[1] for _ in sorted(tuples)]
     rec["version"] = signatures.feature_set_version
-    rec["plane_tag"] = signatures.basename
+    rec["name"] = signatures.basename
     for k in "x", "y", "w", "h":
         rec[k] = getattr(signatures, k)
     return rec

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -32,9 +32,10 @@ class Mapper(api.Mapper):
     def map(self, ctx):
         p = BioImgPlane(ctx.value)
         pixels = p.get_xy()
-        plane_tag = '%s-z%04d-c%04d-t%04d' % (p.name, p.z, p.c, p.t)
         # TODO: support tiling
-        out_rec = to_avro(calc_features(pixels, plane_tag))
+        out_rec = to_avro(calc_features(pixels, p.name))
+        for name in 'img_path', 'series', 'z', 'c', 't':
+            out_rec[name] = getattr(p, name)
         ctx.emit(None, out_rec)
 
 

--- a/scripts/local_features
+++ b/scripts/local_features
@@ -77,12 +77,13 @@ def main(argv):
             for r in reader:
                 p = BioImgPlane(r)
                 pixels = p.get_xy()
-                plane_tag = '%s-z%04d-c%04d-t%04d' % (p.name, p.z, p.c, p.t)
                 if args.verbose:
-                    print '  processing %s' % plane_tag
-                for fv in calc_features(pixels, plane_tag, long=args.long,
-                                        w=args.width, h=args.height):
+                    print '  processing', [p.z, p.c, p.t]
+                kw = {'long': args.long, 'w': args.width, 'h': args.height}
+                for fv in calc_features(pixels, p.name, **kw):
                     out_rec = to_avro(fv)
+                    for name in 'img_path', 'series', 'z', 'c', 't':
+                        out_rec[name] = getattr(p, name)
                     writer.write(out_rec)
         writer.close()
 

--- a/scripts/serialize
+++ b/scripts/serialize
@@ -2,11 +2,6 @@
 
 set -eu
 
-if [ "$#" == 0 ]; then
-    echo "USAGE: ./$(basename "$0") IMG_FILE"
-    exit 2
-fi
-
 SCRIPTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd; cd - >/dev/null)
 REPO_ROOT=$(dirname "${SCRIPTS_DIR}")
 PKG=( "${REPO_ROOT}"/target/pydoop-features-*.jar )

--- a/src/main/avro/bioimg.avdl
+++ b/src/main/avro/bioimg.avdl
@@ -5,7 +5,9 @@ protocol BioImg {
 
   record BioImgPlane {
     string name;
+    string img_path;
     string dimension_order;
+    int series;
     ArraySlice pixel_data;
   }
 

--- a/src/main/avro/featureset.avdl
+++ b/src/main/avro/featureset.avdl
@@ -5,11 +5,10 @@ protocol FeatureSet {
 
   record Signatures {
     string version;
-    string plane_tag;
-    int w;
-    int h;
-    int x;
-    int y;
+    string name;
+    string img_path;
+    int series, z, c, t;
+    int x, y, w, h;
     array<double> chebyshev_coefficients;
     array<double> chebyshev_coefficients_chebyshev;
     array<double> chebyshev_coefficients_edge;

--- a/src/main/java/it/crs4/features/BioImgFactory.java
+++ b/src/main/java/it/crs4/features/BioImgFactory.java
@@ -43,6 +43,7 @@ public class BioImgFactory {
   private static final int N_DIM = DEFAULT_ORDER.length();
 
   protected IFormatReader reader;
+  protected String imgPath;
   protected String dimOrder;
 
   /** current series */
@@ -90,9 +91,10 @@ public class BioImgFactory {
    * being changed by the caller. In particular, reader.setSeries
    * must not be called (call setSeries on the BioImgFactory instead).
    */
-  public BioImgFactory(IFormatReader reader) {
+  public BioImgFactory(IFormatReader reader, String imgPath) {
     this.reader = new ChannelSeparator(reader);
     setSeries(this.reader.getSeries());
+    this.imgPath = imgPath;
   }
 
   public int getSeries() {
@@ -137,7 +139,7 @@ public class BioImgFactory {
     a.setOffsets(Arrays.asList(offsets));
     a.setDeltas(Arrays.asList(deltas));
     a.setData(ByteBuffer.wrap(reader.openBytes(no, x, y, w, h)));
-    return new BioImgPlane(name, dimOrder, a);
+    return new BioImgPlane(name, imgPath, dimOrder, series, a);
   }
 
   public void writeSeries(String name, String fileName)

--- a/src/main/java/it/crs4/features/BioImgRecordReader.java
+++ b/src/main/java/it/crs4/features/BioImgRecordReader.java
@@ -68,7 +68,7 @@ public class BioImgRecordReader
       throw new RuntimeException("FormatException: " + e.getMessage());
     }
     planesPerSeries = reader.getImageCount();
-    factory = new BioImgFactory(reader);
+    factory = new BioImgFactory(reader, absPathName);
     name = PathTools.stripext(PathTools.basename(absPathName));
     planeCounter = 0;
   }

--- a/src/test/java/it/crs4/features/BioImgFactoryTest.java
+++ b/src/test/java/it/crs4/features/BioImgFactoryTest.java
@@ -139,6 +139,7 @@ public class BioImgFactoryTest {
         PLANE_SIZE[seriesIdx] * (sampleIdx + 1)
     );
     assertEquals(p.getDimensionOrder().toString(), DIM_ORDER);
+    assertEquals(p.getSeries().intValue(), seriesIdx);
     ArraySlice a = p.getPixelData();
     assertEquals(a.getDtype(), EXPECTED_DTYPE);
     assertEquals(a.getLittleEndian().booleanValue(), LITTLE_ENDIAN);
@@ -162,7 +163,7 @@ public class BioImgFactoryTest {
     LOGGER.info("Image file: {}", imgFn);
     ImageReader iReader = new ImageReader();
     iReader.setId(imgFn);
-    BioImgFactory factory = new BioImgFactory(iReader);
+    BioImgFactory factory = new BioImgFactory(iReader, imgFn);
     assertEquals(factory.getSeriesCount(), SERIES_COUNT);
     for (int s = 0; s < SERIES_COUNT; s++) {
       LOGGER.info("Series: {}", s);

--- a/test/test_bioimg.py
+++ b/test/test_bioimg.py
@@ -98,7 +98,9 @@ class TestBioImgPlane(TestArraySlice):
         }
         self.record = {
             "name": "foo",
+            "img_path": "/bar/foo.tif",
             "dimension_order": "XYTZC",
+            "series": 0,
             "pixel_data": self.pixel_data,
         }
         self.np_dtype = c["np_dtype"]
@@ -114,8 +116,8 @@ class TestBioImgPlane(TestArraySlice):
             self.np_dtype, deltas
         ).tostring()
         plane = bioimg.BioImgPlane(self.record)
-        self.assertEqual(plane.name, self.record["name"])
-        self.assertEqual(plane.dimension_order, self.record["dimension_order"])
+        for k in "name", "img_path", "dimension_order", "series":
+            self.assertEqual(getattr(plane, k), self.record[k])
         self.assertEqual(plane.z, self.zct["Z"])
         self.assertEqual(plane.c, self.zct["C"])
         self.assertEqual(plane.t, self.zct["T"])

--- a/test/test_pyavroc_emu.py
+++ b/test/test_pyavroc_emu.py
@@ -29,27 +29,32 @@ from pyfeatures.feature_names import FEATURE_NAMES
 class Base(unittest.TestCase):
 
     def setUp(self):
+        name = "img_0"
+        img_path = "/bar/spam/img_0.tif"
+        series = z = c = t = 0
         array_slice = {
             "dtype": "UINT8",
             "little_endian": True,
             "shape": [4, 4, 1, 2, 3],
-            "offsets": [0, 0, 0, 0, 0],
+            "offsets": [0, 0, z, c, t],
             "deltas": [4, 4, 1, 1, 1],
             "data": ''.join(chr(_) for _ in xrange(16))
         }
         signatures = {
             "version": "3.2",
-            "plane_tag": "img_0-z0000-c0000-t0000",
+            "name": name,
+            "img_path": img_path,
+            "series": series, "z": z, "c": c, "t": t,
             "x": 0, "y": 0, "w": 400, "h": 300,
         }
         for vname, idx in FEATURE_NAMES.itervalues():
             signatures.setdefault(vname, []).append(float(idx))
         self.record_map = {
             "BioImgPlane": {
-                "name": "foo",
-                "img_path": "/bar/spam.tif",
+                "name": name,
+                "img_path": img_path,
                 "dimension_order": "XYZCT",
-                "series": 0,
+                "series": series,
                 "pixel_data": array_slice,
             },
             "Signatures": signatures

--- a/test/test_pyavroc_emu.py
+++ b/test/test_pyavroc_emu.py
@@ -47,7 +47,9 @@ class Base(unittest.TestCase):
         self.record_map = {
             "BioImgPlane": {
                 "name": "foo",
+                "img_path": "/bar/spam.tif",
                 "dimension_order": "XYZCT",
+                "series": 0,
                 "pixel_data": array_slice,
             },
             "Signatures": signatures


### PR DESCRIPTION
Until now, this info was encoded in the `plane_tag` field, so that features for, e.g., `/tmp/img.tif` would be characterized by an `img_<S>-z<Z>-c<C>-t<T>` plane tag.

This PR:
 * removes `plane_tag`;
 * adds a `series` integer field to both the input and the output record;
 * adds `z`, `c` and `t` integer fields to the output record (the input record already contains this info);
 * adds an `img_path` field to store the original input file path both to the input and the output record.