### PR TITLE
Add script to compare different tile sizes

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -6,4 +6,4 @@ Licensing
 
 Tests use the following images:
 
- * http://www.cellimagelibrary.org/images/37117, licensed under a [Creative Commons Attribution, Non-Commercial Share Alike License](http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode) ([human readable version](http://creativecommons.org/licenses/by-nc-sa/3.0/)). The version stored here is scaled down to 3% of the original size. The resized version is licensed under the same license.
+ * http://www.cellimagelibrary.org/images/37117, licensed under a [Creative Commons Attribution, Non-Commercial Share Alike License](http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode) ([human readable version](http://creativecommons.org/licenses/by-nc-sa/3.0/)). The version stored here has been scaled down, and is licensed under the same license.

--- a/test/integration/run_tile_size
+++ b/test/integration/run_tile_size
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+
+# FIXME: not an integration test, move elsewhere
+
+import sys
+import os
+import subprocess as sp
+import tempfile
+import time
+from itertools import product
+import argparse
+
+import numpy as np
+
+import pyfeatures.pyavroc_emu as pyavroc_emu
+from pyfeatures.bioimg import BioImgPlane
+from pyfeatures.feature_calc import calc_features
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(os.path.dirname(THIS_DIR))
+
+MIN_W = 200
+MIN_H = 200
+
+
+# very dumb implementation, should be fine for numbers with less than
+# 7-8 digits (hopefully that's the case for image width & height)
+def get_divisors(n, low=1):
+    for i in xrange(n, 0, -1):
+        if n % i == 0:
+            yield i
+        if i <= low:
+            break
+
+
+def run_serialize(img_fn, out_dir):
+    prog = os.path.join(REPO_ROOT, "scripts", "serialize")
+    sp.check_call([prog, "-o", out_dir, img_fn])
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("img_fn", metavar="IMG_FILE", help="input image file")
+    parser.add_argument("-o", "--out-fn", metavar="FILE", default="stats.tsv",
+                        help="output filename")
+    parser.add_argument("-l", "--long", action="store_true",
+                        help="extract WND-CHARM's \"long\" features set")
+    parser.add_argument("-W", "--min-width", type=int, metavar="INT",
+                        help="minimum tile width (default = %s)" % MIN_W)
+    parser.add_argument("-H", "--min-height", type=int, metavar="INT",
+                        help="minimum tile height (default = %s)" % MIN_H)
+    return parser
+
+
+def main(argv):
+    parser = make_parser()
+    args = parser.parse_args(argv)
+    wd = tempfile.mkdtemp(prefix="pyfeatures_")
+    print "working dir: %r" % (wd,)
+    avro_input_dir = os.path.join(wd, "avro_in")
+    run_serialize(args.img_fn, avro_input_dir)
+    basenames = sorted(os.listdir(avro_input_dir))
+    bn = basenames[0]
+    fn = os.path.join(avro_input_dir, bn)
+    print "reading from: %r" % (fn,)
+    with open(fn) as f:
+        reader = pyavroc_emu.AvroFileReader(f)
+        r = reader.next()
+    p = BioImgPlane(r)
+    print "taking first plane: %r" % [p.z, p.c, p.t]
+    pixels = p.get_xy()
+    H, W = pixels.shape
+    print "[W, H] = %r" % [W, H]
+    print "computing reference features..."
+    start = time.time()
+    ref_v = list(calc_features(pixels, p.name, long=args.long))[0].values
+    delta = time.time() - start
+    with open(args.out_fn, "w") as fo:
+        fo.write("W\tH\t\tELAPSED_T\tERROR\n")
+        fo.write("%d\t%d\t%.5f\t%.5f\n" % (W, H, delta, 0))
+        for w, h in product(get_divisors(W, low=args.min_width),
+                            get_divisors(H, low=args.min_height)):
+            if w == W and h == H:
+                continue
+            m, M = sorted((w, h))
+            if m <= M // 2:
+                continue  # avoid long stripes
+            print "computing features with %d x %d tiles..." % (w, h)
+            start = time.time()
+            all_vs = [_.values for _ in calc_features(
+                pixels, p.name, long=args.long, w=w, h=h
+            )]
+            delta = time.time() - start
+            mean_v = np.mean(all_vs, axis=0)
+            error = np.linalg.norm(mean_v - ref_v)  # euclidean distance
+            fo.write("%d\t%d\t%.5f\t%.5f\n" % (w, h, delta, error))
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
Adds a script that runs feature calculation first without tiling (i.e., one tile that coincides with the whole image) and then with decreasing tile sizes, measuring both computing time and accuracy (euclidean distance between the feature vector for the whole image and the mean feature vector across all tiles).