### PR TITLE
Run tests with pyavroc as the Avro implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
   - "2.7"
 
+env:
+  - AVRO=avro
+  - AVRO=pyavroc
+
 # This (sudo: false) is needed to "run on container-based infrastructure" on
 # which cache: is available
 # http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -27,10 +31,10 @@ before_install:
   - pip install --upgrade pip
   - pip install numpy
   - pip install scipy
-  - pip install avro
   - pip install flake8
   - pip install libtiff
   - pip install matplotlib
+  - bash .travis/install_avro.sh "${AVRO}"
   - bash .travis/install_wndcharm.sh
 
 install:

--- a/.travis/install_avro.sh
+++ b/.travis/install_avro.sh
@@ -1,0 +1,26 @@
+set -eux
+
+install_pyavroc() {
+    pip install pytest
+    pushd /tmp
+    git clone --depth=1 -b master https://github.com/Byhiras/pyavroc.git
+    pushd pyavroc
+    git clone --depth=1 -b patches https://github.com/Byhiras/avro.git \
+	local_avro
+    ./clone_avro_and_build.sh --static
+    python setup.py install --skip-build
+    popd
+    popd
+}
+
+case "${1}" in
+    "avro")
+	pip install avro
+	;;
+    "pyavroc")
+	install_pyavroc
+	;;
+    *)
+	echo "Usage: bash $0 [avro|pyavroc]" 1>&2
+	exit 1
+esac

--- a/.travis/install_avro.sh
+++ b/.travis/install_avro.sh
@@ -11,6 +11,9 @@ install_pyavroc() {
     python setup.py install --skip-build
     popd
     popd
+    # --- FIXME: pyavroc_emu is currently imported unconditionally ---
+    pip install avro
+    # ----------------------------------------------------------------
 }
 
 case "${1}" in


### PR DESCRIPTION
Adds a Travis test scenario where [pyavroc](https://github.com/Byhiras/pyavroc) is installed and thus used for Avro I/O instead of the official API.