### PR TITLE
Add options to serialize a subset of planes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ instance, download
 and unpack it under `/tmp`. The first step is to serialize this data
 to Avro:
 
-    docker run -u ${UID} -v /tmp:/tmp simleo/pyfeatures \
+    docker run -u ${UID} --rm -v /tmp:/tmp simleo/pyfeatures \
       serialize /tmp/MF-2CH-Z-T.tif -o /tmp/
 
 You should get one avro container file per image series in the input
@@ -38,7 +38,7 @@ dataset. In this case:
 
 To compute features for the first avro container:
 
-    docker run -u ${UID} -v /tmp:/tmp simleo/pyfeatures \
+    docker run -u ${UID} --rm -v /tmp:/tmp simleo/pyfeatures \
       calc /tmp/MF-2CH-Z-T_0.avro -o /tmp/
 
 You might want to get a cup of coffee, feature calculation takes time.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -127,7 +127,7 @@
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength"/>
         <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
+        <!-- <module name="ParameterNumber"/> -->
 
 
         <!-- Checks for whitespace                               -->

--- a/pyfeatures/app/calc.py
+++ b/pyfeatures/app/calc.py
@@ -44,6 +44,13 @@ logging.basicConfig(level=logging.INFO)
 
 
 def run(args, extra_argv=None):
+    if args.stderr:
+        # Log to file instead of default stderr
+        fileh = logging.FileHandler(args.stderr)
+        rootlogger = logging.getLogger()
+        for h in rootlogger.handlers:
+            rootlogger.removeHandler(h)
+        rootlogger.addHandler(fileh)
     logger = logging.getLogger("calc")
     logger.setLevel(args.log_level)
     try:
@@ -75,6 +82,7 @@ def run(args, extra_argv=None):
                         out_rec[name] = getattr(p, name)
                     writer.write(out_rec)
         writer.close()
+    logger.info("All done")
     return 0
 
 

--- a/pyfeatures/app/calc.py
+++ b/pyfeatures/app/calc.py
@@ -40,7 +40,8 @@ from pyfeatures.bioimg import BioImgPlane
 from pyfeatures.feature_calc import calc_features, to_avro
 from pyfeatures.schema import Signatures as out_schema
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO, format='%(asctime)-15s %(levelname)s: %(message)s')
 
 
 def run(args, extra_argv=None):

--- a/pyfeatures/app/main.py
+++ b/pyfeatures/app/main.py
@@ -21,7 +21,9 @@ Pyfeatures command line tool.
 """
 
 import argparse
+import errno
 import importlib
+import os
 
 from .common import log_level
 
@@ -55,7 +57,21 @@ def make_parser():
     return parser
 
 
+def create_log_dirs(args):
+    for f in [args.stdout, args.stderr]:
+        d = os.path.dirname(f) if f else None
+        if d:
+            try:
+                os.makedirs(d)
+            except OSError as e:
+                if e.errno == errno.EEXIST and os.path.isdir(d):
+                    pass
+                else:
+                    raise
+
+
 def main(argv=None):
     parser = make_parser()
     args, extra_argv = parser.parse_known_args(argv)
+    create_log_dirs(args)
     args.func(args, extra_argv=extra_argv)

--- a/pyfeatures/app/main.py
+++ b/pyfeatures/app/main.py
@@ -46,6 +46,8 @@ def make_parser():
                         help='print version tag and exit')
     parser.add_argument('--log-level', metavar="LEVEL", type=log_level,
                         default="INFO", help="logging level")
+    parser.add_argument('--stdout', help="Redirect stdout to this file")
+    parser.add_argument('--stderr', help="Redirect stderr to this file")
     subparsers = parser.add_subparsers(help="sub-commands")
     for n in SUBMOD_NAMES:
         mod = importlib.import_module("%s.%s" % (__package__, n))

--- a/pyfeatures/app/serialize.py
+++ b/pyfeatures/app/serialize.py
@@ -33,7 +33,7 @@ def run(args, extra_argv=None):
     sp_argv = ["java", "-cp", JAR_PATH, "it.crs4.features.ImageToAvro"]
     sp_argv.extend(extra_argv)
     try:
-        sp.check_call(sp_argv)
+        sp.check_call(sp_argv, stdout=args.stdout, stderr=args.stderr)
     except sp.CalledProcessError:
         if extra_argv:
             raise

--- a/pyfeatures/app/serialize.py
+++ b/pyfeatures/app/serialize.py
@@ -35,11 +35,22 @@ def run(args, extra_argv=None):
         for prop in args.java_d:
             java.append('-D%s' % prop)
     sp_argv = java + ["it.crs4.features.ImageToAvro"] + extra_argv
+    stdout = None
+    stderr = None
     try:
-        sp.check_call(sp_argv, stdout=args.stdout, stderr=args.stderr)
+        if args.stdout:
+            stdout = open(args.stdout, 'a')
+        if args.stderr:
+            stderr = open(args.stderr, 'a')
+        sp.check_call(sp_argv, stdout=stdout, stderr=stderr)
     except sp.CalledProcessError:
         if extra_argv:
             raise
+
+    if stdout:
+        stdout.close()
+    if stderr:
+        stderr.close()
     return 0
 
 

--- a/pyfeatures/app/serialize.py
+++ b/pyfeatures/app/serialize.py
@@ -30,8 +30,11 @@ from pyfeatures import JAR_PATH
 def run(args, extra_argv=None):
     if extra_argv is None:
         extra_argv = []
-    sp_argv = ["java", "-cp", JAR_PATH, "it.crs4.features.ImageToAvro"]
-    sp_argv.extend(extra_argv)
+    java = ["java", "-cp", JAR_PATH]
+    if args.java_d:
+        for prop in args.java_d:
+            java.append('-D%s' % prop)
+    sp_argv = java + ["it.crs4.features.ImageToAvro"] + extra_argv
     try:
         sp.check_call(sp_argv, stdout=args.stdout, stderr=args.stderr)
     except sp.CalledProcessError:
@@ -46,5 +49,7 @@ def add_parser(subparsers):
         description=__doc__,
         epilog="Run without arguments to print the Java help."
     )
+    parser.add_argument('-D', dest='java_d', metavar='JAVA_PROPERTY',
+                        nargs='+', help='Java properties')
     parser.set_defaults(func=run)
     return parser

--- a/src/main/java/it/crs4/features/BioImgFactory.java
+++ b/src/main/java/it/crs4/features/BioImgFactory.java
@@ -122,10 +122,10 @@ public class BioImgFactory {
     }
     int[] zct = reader.getZCTCoords(no);
 
-    if (!zs.isEmpty() && !zs.contains(zct[0])) {
+    if (null != zs && !zs.contains(zct[0])) {
       return null;
     }
-    if (!ts.isEmpty() && !ts.contains(zct[2])) {
+    if (null != ts && !ts.contains(zct[2])) {
       return null;
     }
 

--- a/src/main/java/it/crs4/features/BioImgFactory.java
+++ b/src/main/java/it/crs4/features/BioImgFactory.java
@@ -111,7 +111,8 @@ public class BioImgFactory {
     return build(name, no, 0, 0, -1, -1, null, null);
   }
 
-  public BioImgPlane build(String name, int no, int x, int y, int w, int h, HashSet<Integer> zs, HashSet<Integer> ts)
+  public BioImgPlane build(String name, int no, int x, int y, int w, int h,
+                           HashSet<Integer> zs, HashSet<Integer> ts)
       throws FormatException, IOException {
     if (w < 0) {
       w = shape.get(dimIdx[0]);
@@ -157,7 +158,8 @@ public class BioImgFactory {
   }
 
   public void writeSeries(String name, String fileName,
-                          int x, int y, int w, int h, HashSet<Integer> zs, HashSet<Integer> ts)
+                          int x, int y, int w, int h,
+                          HashSet<Integer> zs, HashSet<Integer> ts)
       throws FormatException, IOException {
     DataFileWriter<BioImgPlane> writer = new DataFileWriter<BioImgPlane>(
       new SpecificDatumWriter<BioImgPlane>(BioImgPlane.class)

--- a/src/main/java/it/crs4/features/ImageToAvro.java
+++ b/src/main/java/it/crs4/features/ImageToAvro.java
@@ -21,6 +21,7 @@
 package it.crs4.features;
 
 import java.io.File;
+import java.util.HashSet;
 
 import loci.formats.IFormatReader;
 import loci.formats.ImageReader;
@@ -50,6 +51,8 @@ public final class ImageToAvro {
     opts.addOption("t", "tag", true, "base tag for the avro output file");
     opts.addOption("w", "memoWait", true, "Memoizer wait (advanced)");
     opts.addOption("d", "memoDir", true, "Memoizer directory (advanced)");
+    opts.addOption("zs", "zsubset", true, "Subset of Z planes");
+    opts.addOption("ts", "tsubset", true, "Subset of T planes");
     CommandLineParser parser = new GnuParser();
     return parser.parse(opts, args);
   }
@@ -105,6 +108,22 @@ public final class ImageToAvro {
       reader = new Memoizer(reader, memoWait, memoDir);
     }
 
+    HashSet<Integer> zs = new HashSet<Integer>();
+    if (cmd.hasOption("zsubset")) {
+      String zsubset = cmd.getOptionValue("zsubset");
+      for (String s: zsubset.split(",")) {
+        zs.add(Integer.parseInt(s));
+      }
+    }
+
+    HashSet<Integer> ts = new HashSet<Integer>();
+    if (cmd.hasOption("tsubset")) {
+      String tsubset = cmd.getOptionValue("tsubset");
+      for (String s: tsubset.split(",")) {
+        ts.add(Integer.parseInt(s));
+      }
+    }
+
     LOGGER.info("Reading from {}", fn);
     BioImgFactory factory = new BioImgFactory(reader, imgPath);
     int seriesCount = factory.getSeriesCount();
@@ -116,7 +135,7 @@ public final class ImageToAvro {
       name = String.format("%s_%d", tag, i);
       outFn = new File(outDirName, name + ".avro").getPath();
       factory.setSeries(i);
-      factory.writeSeries(name, outFn);
+      factory.writeSeries(name, outFn, 0, 0, -1, -1, zs, ts);
       LOGGER.info("Writing to {}", outFn);
     }
     reader.close();


### PR DESCRIPTION
Adds two new options, `-zs/--zsubset` and `-ts/--tsubset` for serialising a subset of planes, default is all.

    pyfeatures serialize -o out multi-channel-4D-series.ome.tif -ts 1,3 -zs 2,3

extracts ZCT `(2, 0, 1), (3, 0, 1), (2, 1, 1), (3, 1, 1), (2, 2, 1), (3, 2, 1), (2, 0, 3), (3, 0, 3), (2, 1, 3), (3, 1, 3), (2, 2, 3), (3, 2, 3)`

    pyfeatures serialize -o out multi-channel-4D-series.ome.tif -ts 2,4

extracts ZCT `(0, 0, 2), (1, 0, 2), (2, 0, 2), (3, 0, 2), (4, 0, 2), (0, 1, 2), (1, 1, 2), (2, 1, 2), (3, 1, 2), (4, 1, 2), (0, 2, 2), (1, 2, 2), (2, 2, 2), (3, 2, 2), (4, 2, 2), (0, 0, 4), (1, 0, 4), (2, 0, 4), (3, 0, 4), (4, 0, 4), (0, 1, 4), (1, 1, 4), (2, 1, 4), (3, 1, 4), (4, 1, 4), (0, 2, 4), (1, 2, 4), (2, 2, 4), (3, 2, 4), (4, 2, 4)`

I've created a temporary docker hub build for testing:
- https://github.com/manics/pydoop-features/commit/a3689e89f6bd75b1e5eadc895c7e0de2e25cfe4d
- https://hub.docker.com/r/manics/pyfeatures/

Possible todos:
- [ ] Tests?
- [ ] Docs?
- [ ] Argument names?
- [ ] Output file names (should it indicate it's a subset of planes)?