### PR TITLE
Fix serialize default case

### DIFF
--- a/src/main/java/it/crs4/features/ImageToAvro.java
+++ b/src/main/java/it/crs4/features/ImageToAvro.java
@@ -108,16 +108,18 @@ public final class ImageToAvro {
       reader = new Memoizer(reader, memoWait, memoDir);
     }
 
-    HashSet<Integer> zs = new HashSet<Integer>();
+    HashSet<Integer> zs = null;
     if (cmd.hasOption("zsubset")) {
+      zs = new HashSet<Integer>();
       String zsubset = cmd.getOptionValue("zsubset");
       for (String s: zsubset.split(",")) {
         zs.add(Integer.parseInt(s));
       }
     }
 
-    HashSet<Integer> ts = new HashSet<Integer>();
+    HashSet<Integer> ts = null;
     if (cmd.hasOption("tsubset")) {
+      ts = new HashSet<Integer>();
       String tsubset = cmd.getOptionValue("tsubset");
       for (String s: tsubset.split(",")) {
         ts.add(Integer.parseInt(s));

--- a/test/integration/run_local_features
+++ b/test/integration/run_local_features
@@ -60,7 +60,9 @@ def main():
     avro_output_dir = os.path.join(wd, "avro_out")
     img_output_dir = os.path.join(wd, "planes")
     run_serialize(IMG_FN, avro_input_dir)
-    for bn in os.listdir(avro_input_dir):
+    basenames = os.listdir(avro_input_dir)
+    assert len(basenames) > 0
+    for bn in basenames:
         fn = os.path.join(avro_input_dir, bn)
         run_deserialize(fn, img_output_dir)  # for visual inspection
         run_feature_calc(fn, avro_output_dir)


### PR DESCRIPTION
https://github.com/manics/pydoop-features/pull/3 fixed the "no selection" use case only when using `BioImgFactory` directly. `ImageToAvro`, though, was still broken because it wasn't changed to pass `null` sets. This led to no avro file being generated, and the integration test wasn't able to detect this.