### PR TITLE
Add test for ImageToAvro

### DIFF
--- a/src/main/java/it/crs4/features/BioImgFactory.java
+++ b/src/main/java/it/crs4/features/BioImgFactory.java
@@ -22,7 +22,7 @@ package it.crs4.features;
 
 import java.util.List;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Set;
 import java.nio.ByteBuffer;
 import java.io.IOException;
 import java.io.File;
@@ -112,7 +112,7 @@ public class BioImgFactory {
   }
 
   public BioImgPlane build(String name, int no, int x, int y, int w, int h,
-                           HashSet<Integer> zs, HashSet<Integer> ts)
+                           Set<Integer> zs, Set<Integer> ts)
       throws FormatException, IOException {
     if (w < 0) {
       w = shape.get(dimIdx[0]);
@@ -159,7 +159,7 @@ public class BioImgFactory {
 
   public void writeSeries(String name, String fileName,
                           int x, int y, int w, int h,
-                          HashSet<Integer> zs, HashSet<Integer> ts)
+                          Set<Integer> zs, Set<Integer> ts)
       throws FormatException, IOException {
     DataFileWriter<BioImgPlane> writer = new DataFileWriter<BioImgPlane>(
       new SpecificDatumWriter<BioImgPlane>(BioImgPlane.class)

--- a/src/main/java/it/crs4/features/ImageToAvro.java
+++ b/src/main/java/it/crs4/features/ImageToAvro.java
@@ -21,6 +21,7 @@
 package it.crs4.features;
 
 import java.io.File;
+import java.util.Set;
 import java.util.HashSet;
 
 import loci.formats.IFormatReader;
@@ -108,7 +109,7 @@ public final class ImageToAvro {
       reader = new Memoizer(reader, memoWait, memoDir);
     }
 
-    HashSet<Integer> zs = null;
+    Set<Integer> zs = null;
     if (cmd.hasOption("zsubset")) {
       zs = new HashSet<Integer>();
       String zsubset = cmd.getOptionValue("zsubset");
@@ -117,7 +118,7 @@ public final class ImageToAvro {
       }
     }
 
-    HashSet<Integer> ts = null;
+    Set<Integer> ts = null;
     if (cmd.hasOption("tsubset")) {
       ts = new HashSet<Integer>();
       String tsubset = cmd.getOptionValue("tsubset");

--- a/src/test/java/it/crs4/features/BioImgFactoryTest.java
+++ b/src/test/java/it/crs4/features/BioImgFactoryTest.java
@@ -238,8 +238,7 @@ public class BioImgFactoryTest {
       avroFiles[s] = avroF;
       factory.setSeries(s);
       assertEquals(factory.getSeries(), s);
-      factory.writeSeries(name, avroFn, 0, 0, -1, -1,
-                          (HashSet) zs, (HashSet) ts);
+      factory.writeSeries(name, avroFn, 0, 0, -1, -1, zs, ts);
     }
     reader.close();
     return avroFiles;
@@ -273,8 +272,8 @@ public class BioImgFactoryTest {
 
   @Test
   public void testPlaneSubset() throws Exception {
-    HashSet<Integer> zs = new HashSet(Arrays.asList(0, 3));
-    HashSet<Integer> ts = new HashSet(Arrays.asList(1));
+    Set<Integer> zs = new HashSet(Arrays.asList(0, 3));
+    Set<Integer> ts = new HashSet(Arrays.asList(1));
     File[] avroFiles = dumpToAvro(zs, ts);
     for (int s = 0; s < SERIES_COUNT; s++) {
       List<Integer> expIndices = new ArrayList<Integer>();

--- a/src/test/java/it/crs4/features/BioImgFactoryTest.java
+++ b/src/test/java/it/crs4/features/BioImgFactoryTest.java
@@ -64,19 +64,19 @@ public class BioImgFactoryTest {
     BioImgFactoryTest.class);
 
   // independent
-  private static final String NAME = "pydoop_features_test";
-  private static final boolean LITTLE_ENDIAN = true;
-  private static final int PIXEL_TYPE = FormatTools.UINT16;
-  private static final DType EXPECTED_DTYPE = DType.UINT16;
-  private static final String DIM_ORDER = "XYCZT";
-  private static final int SERIES_COUNT = 2;
+  static final String NAME = "pydoop_features_test";
+  static final boolean LITTLE_ENDIAN = true;
+  static final int PIXEL_TYPE = FormatTools.UINT16;
+  static final DType EXPECTED_DTYPE = DType.UINT16;
+  static final String DIM_ORDER = "XYCZT";
+  static final int SERIES_COUNT = 2;
   // use different size{X,Y,Z} for the two series
-  private static final int[] SIZE_X = {512, 256};
-  private static final int[] SIZE_Y = {256, 128};
-  private static final int[] SIZE_Z = {5, 4};
-  private static final int EFF_SIZE_C = 1;
-  private static final int SIZE_T = 2;
-  private static final int SPP = 3;  // Samples per pixel (e.g., 3 for RGB)
+  static final int[] SIZE_X = {512, 256};
+  static final int[] SIZE_Y = {256, 128};
+  static final int[] SIZE_Z = {5, 4};
+  static final int EFF_SIZE_C = 1;
+  static final int SIZE_T = 2;
+  static final int SPP = 3;  // Samples per pixel (e.g., 3 for RGB)
 
   // dependent
   private static final int[] PLANE_SIZE = {
@@ -98,7 +98,7 @@ public class BioImgFactoryTest {
   private static final int SIZE_C = SPP * EFF_SIZE_C;
 
   private static byte[][][] data;
-  private static File target;
+  private static String imgFn;
 
   // store zct -> index mapping for all series
   private static List<Map<List<Integer>, Integer>> zct2i =
@@ -132,8 +132,12 @@ public class BioImgFactoryTest {
   @BeforeClass
   public static void makeImgFile() throws Exception {
     LOGGER.info("wd: {}", wd.getRoot());
-    target = wd.newFile(String.format("%s.ome.tiff", NAME));
-    String imgFn = target.getAbsolutePath();
+    imgFn = makeImgFile(wd);
+  }
+
+  public static String makeImgFile(TemporaryFolder dir) throws Exception {
+    String bn = String.format("%s.ome.tiff", NAME);
+    String fn = dir.newFile(bn).getAbsolutePath();
     String ptString = FormatTools.getPixelTypeString(PIXEL_TYPE);
     ServiceFactory factory = new ServiceFactory();
     OMEXMLService service = factory.getInstance(OMEXMLService.class);
@@ -144,7 +148,7 @@ public class BioImgFactoryTest {
     }
     IFormatWriter writer = new ImageWriter();
     writer.setMetadataRetrieve(meta);
-    writer.setId(imgFn);
+    writer.setId(fn);
     writer.setInterleaved(false);
     data = new byte[SERIES_COUNT][][];
     for (int s = 0; s < SERIES_COUNT; s++) {
@@ -159,7 +163,7 @@ public class BioImgFactoryTest {
     writer.close();
     //-- Store zct -> index mapping --
     IFormatReader reader = new ImageReader();
-    reader.setId(imgFn);
+    reader.setId(fn);
     reader = new ChannelSeparator(reader);
     for (int s = 0; s < SERIES_COUNT; s++) {
       reader.setSeries(s);
@@ -172,6 +176,7 @@ public class BioImgFactoryTest {
         }
       }
     }
+    return fn;
   }
 
   private int checkPlane(BioImgPlane p, int seriesIdx) {
@@ -222,7 +227,6 @@ public class BioImgFactoryTest {
   }
 
   private File[] dumpToAvro(Set<Integer> zs, Set<Integer> ts) throws Exception {
-    String imgFn = target.getAbsolutePath();
     LOGGER.info("Image file: {}", imgFn);
     IFormatReader reader = new ImageReader();
     reader.setId(imgFn);

--- a/src/test/java/it/crs4/features/ImageToAvroTest.java
+++ b/src/test/java/it/crs4/features/ImageToAvroTest.java
@@ -1,0 +1,56 @@
+/**
+ * BEGIN_COPYRIGHT
+ *
+ * Copyright (C) 2016 Open Microscopy Environment:
+ *   - University of Dundee
+ *   - CRS4
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * END_COPYRIGHT
+ */
+
+package it.crs4.features;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.junit.ClassRule;
+import org.junit.BeforeClass;
+import org.junit.rules.TemporaryFolder;
+
+
+public class ImageToAvroTest {
+
+  private static String imgFn;
+
+  @ClassRule
+  public static TemporaryFolder wd = new TemporaryFolder();
+
+  @BeforeClass
+  public static void makeImgFile() throws Exception {
+    imgFn = BioImgFactoryTest.makeImgFile(wd);
+  }
+
+  @Test
+  public void testMain() throws Exception {
+    File outDir = new File(wd.getRoot(), "out");
+    outDir.mkdir();
+    ImageToAvro.main(new String[] {imgFn, "-o", outDir.getAbsolutePath()});
+    File[] files = outDir.listFiles();
+    assertEquals(files.length, BioImgFactoryTest.SERIES_COUNT);
+  }
+
+}


### PR DESCRIPTION
Adds a **minimal** unit test for `ImageToAvro`. Also fixes the usage of `Set` vs `HashSet`.

The test should be expanded in a future PR, when time permits.