### PR TITLE
Fix logging

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -15,6 +15,7 @@ RUN yum -y install \
     python27 \
     python27-devel \
     python27-scipy \
+    python27-tkinter \
     swig \
     tar
 RUN echo ". /opt/rh/python27/enable" >/etc/profile.d/python.sh

--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
+          <descriptors>
+            <descriptor>src/assembly/deps-and-log-config.xml</descriptor>
+          </descriptors>
           <appendAssemblyId>false</appendAssemblyId>
         </configuration>
         <executions>

--- a/pyfeatures/app/calc.py
+++ b/pyfeatures/app/calc.py
@@ -28,7 +28,6 @@ import sys
 import os
 import warnings
 import errno
-import logging
 
 try:
     from pyavroc import AvroFileReader, AvroFileWriter
@@ -40,22 +39,8 @@ from pyfeatures.bioimg import BioImgPlane
 from pyfeatures.feature_calc import calc_features, to_avro
 from pyfeatures.schema import Signatures as out_schema
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)-15s %(levelname)s: [%(module)s] %(message)s'
-)
 
-
-def run(args, extra_argv=None):
-    if args.stderr:
-        # Log to file instead of default stderr
-        fileh = logging.FileHandler(args.stderr)
-        rootlogger = logging.getLogger()
-        for h in rootlogger.handlers:
-            rootlogger.removeHandler(h)
-        rootlogger.addHandler(fileh)
-    logger = logging.getLogger("calc")
-    logger.setLevel(args.log_level)
+def run(logger, args, extra_argv=None):
     try:
         os.makedirs(args.out_dir)
     except OSError as e:
@@ -85,7 +70,6 @@ def run(args, extra_argv=None):
                         out_rec[name] = getattr(p, name)
                     writer.write(out_rec)
         writer.close()
-    logger.info("All done")
     return 0
 
 

--- a/pyfeatures/app/calc.py
+++ b/pyfeatures/app/calc.py
@@ -41,7 +41,9 @@ from pyfeatures.feature_calc import calc_features, to_avro
 from pyfeatures.schema import Signatures as out_schema
 
 logging.basicConfig(
-    level=logging.INFO, format='%(asctime)-15s %(levelname)s: %(message)s')
+    level=logging.INFO,
+    format='%(asctime)-15s %(levelname)s: [%(module)s] %(message)s'
+)
 
 
 def run(args, extra_argv=None):

--- a/pyfeatures/app/deserialize.py
+++ b/pyfeatures/app/deserialize.py
@@ -45,7 +45,7 @@ def iterplanes(avro_file):
             yield BioImgPlane(r)
 
 
-def run(args, extra_argv=None):
+def run(logger, args, extra_argv=None):
     try:
         os.makedirs(args.out_dir)
     except OSError as e:
@@ -54,6 +54,7 @@ def run(args, extra_argv=None):
     for p in iterplanes(args.avro_file):
         pixels = p.get_xy()
         out_tag = '%s-z%04d-c%04d-t%04d' % (p.name, p.z, p.c, p.t)
+        logger.info("writing plane %s", out_tag)
         if args.img:
             out_fn = os.path.join(args.out_dir, '%s.tif' % out_tag)
             with closing(TIFF.open(out_fn, mode="w")) as fo:

--- a/pyfeatures/app/dump.py
+++ b/pyfeatures/app/dump.py
@@ -25,7 +25,6 @@ suitable for very large files.
 """
 
 import cPickle
-import logging
 import os
 import pprint
 import shelve
@@ -37,8 +36,6 @@ try:
 except ImportError:
     from pyfeatures.pyavroc_emu import AvroFileReader
     warnings.warn("pyavroc not found, using standard avro lib\n")
-
-logging.basicConfig(level=logging.INFO)
 
 
 FORMATS = "db", "pickle", "txt"
@@ -100,12 +97,11 @@ def add_parser(subparsers):
     return parser
 
 
-def run(args, extra_argv=None):
-    logger = logging.getLogger("dump")
-    logger.setLevel(args.log_level)
+def run(logger, args, extra_argv=None):
     if not args.out_fn:
         tag = os.path.splitext(os.path.basename(args.in_fn))[0]
         args.out_fn = "%s.%s" % (tag, args.format)
+    logger.info("writing to %s", args.out_fn)
     with open(args.in_fn) as f:
         records = iter_records(f, logger, num_records=args.num_records)
         Writer(args.format, args.out_fn).write(records)

--- a/pyfeatures/app/plot.py
+++ b/pyfeatures/app/plot.py
@@ -30,7 +30,6 @@ import sys
 import errno
 import cPickle
 import shelve
-import logging
 import warnings
 from contextlib import closing
 
@@ -42,8 +41,6 @@ except ImportError:
     from pyfeatures.pyavroc_emu import AvroFileReader
     warnings.warn("pyavroc not found, using standard avro lib\n")
 from pyfeatures.feature_names import FEATURE_NAMES
-
-logging.basicConfig(level=logging.INFO)
 
 
 AXES = "z", "c", "t"
@@ -136,9 +133,7 @@ def add_parser(subparsers):
     return parser
 
 
-def run(args, extra_argv=None):
-    logger = logging.getLogger("plot")
-    logger.setLevel(args.log_level)
+def run(logger, args, extra_argv=None):
     try:
         os.makedirs(args.out_dir)
     except OSError as e:

--- a/pyfeatures/app/serialize.py
+++ b/pyfeatures/app/serialize.py
@@ -27,7 +27,7 @@ import subprocess as sp
 from pyfeatures import JAR_PATH
 
 
-def run(args, extra_argv=None):
+def run(logger, args, extra_argv=None):
     if extra_argv is None:
         extra_argv = []
     java = ["java", "-cp", JAR_PATH]
@@ -35,22 +35,12 @@ def run(args, extra_argv=None):
         for prop in args.java_d:
             java.append('-D%s' % prop)
     sp_argv = java + ["it.crs4.features.ImageToAvro"] + extra_argv
-    stdout = None
-    stderr = None
+    logger.debug("subprocess args: %r", sp_argv)
     try:
-        if args.stdout:
-            stdout = open(args.stdout, 'a')
-        if args.stderr:
-            stderr = open(args.stderr, 'a')
-        sp.check_call(sp_argv, stdout=stdout, stderr=stderr)
+        sp.check_call(sp_argv)
     except sp.CalledProcessError:
         if extra_argv:
             raise
-
-    if stdout:
-        stdout.close()
-    if stderr:
-        stderr.close()
     return 0
 
 

--- a/pyfeatures/app/tiles.py
+++ b/pyfeatures/app/tiles.py
@@ -21,15 +21,11 @@ Generate tiles according to the given parameters and output a
 visual representation of the resulting coverage.
 """
 
-import logging
-
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 
 from pyfeatures.feature_calc import gen_tiles
-
-logging.basicConfig(level=logging.INFO)
 
 
 IMG_ALPHA = 0.2
@@ -51,9 +47,7 @@ def add_parser(subparsers):
     return parser
 
 
-def run(args, extra_argv=None):
-    logger = logging.getLogger("tiles")
-    logger.setLevel(args.log_level)
+def run(logger, args, extra_argv=None):
     img_array = np.zeros((args.iH, args.iW), dtype="i1")
     fig = plt.figure()
     ax = fig.add_subplot(111, aspect='equal')

--- a/src/assembly/deps-and-log-config.xml
+++ b/src/assembly/deps-and-log-config.xml
@@ -1,0 +1,43 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+
+  <!--
+      Based on the jar-with-dependencies pre-defined descriptor. Adds
+      directives to ignore log4j config files from dependencies (one
+      would be added at the top level by Hadoop) and to add our own.
+  -->
+
+  <id>deps-and-log-config</id>
+
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <fileSets>
+    <fileSet>
+      <directory>src/test/resources</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>log4j.properties</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <unpackOptions>
+        <excludes>
+          <exclude>**/log4j.properties</exclude>
+        </excludes>
+      </unpackOptions>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+
+</assembly>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO, A1
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+log4j.rootLogger=INFO,console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %p: [%c] %m%n


### PR DESCRIPTION
This PR addresses a number of problems with the logging setup:

Java logging config
-------------------
Due to Maven's previous configuration (or lack thereof) for the assembly jar, we had no control over the Java logging output (the application was reading a log4j config from one of the dependencies). This PR changes the log4j config to output dates in the ISO8601 format and makes sure that it gets installed in the assembly jar.

Stream redirection
------------------
The stdout / stderr redirection feature in the Python app was misleading, because only part of the streams were actually being redirected:

```
[simleo@simleo-U36SD:pydoop-features (logging)]$ pyfeatures --stderr err --stdout out serialize test/integration/37117_small.tif 
[simleo@simleo-U36SD:pydoop-features (logging)]$ head out err
==> out <==
2016-08-31 08:49:55,384 INFO: [loci.formats.ImageReader] OMETiffReader initializing test/integration/37117_small.tif
2016-08-31 08:49:55,421 INFO: [loci.formats.in.MinimalTiffReader] Reading IFDs
2016-08-31 08:49:55,422 INFO: [loci.formats.in.MinimalTiffReader] Populating metadata
2016-08-31 08:49:55,431 INFO: [it.crs4.features.ImageToAvro] Reading from test/integration/37117_small.tif
2016-08-31 08:49:55,643 INFO: [it.crs4.features.ImageToAvro] Writing to 37117_small_0.avro
2016-08-31 08:49:55,644 INFO: [it.crs4.features.ImageToAvro] All done
==> err <==


[simleo@simleo-U36SD:pydoop-features (logging)]$ pyfeatures --stderr err --stdout out serialize README.md 
Traceback (most recent call last):
  File "/home/simleo/.local/bin/pyfeatures", line 33, in <module>
    main(sys.argv[1:])
  File "/home/simleo/.local/lib/python2.7/site-packages/pyfeatures/app/main.py", line 77, in main
    args.func(args, extra_argv=extra_argv)
  File "/home/simleo/.local/lib/python2.7/site-packages/pyfeatures/app/serialize.py", line 45, in run
    sp.check_call(sp_argv, stdout=stdout, stderr=stderr)
  File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['java', '-cp', '/home/simleo/.local/lib/python2.7/site-packages/pyfeatures/pydoop-features-1.0-SNAPSHOT.jar', 'it.crs4.features.ImageToAvro', 'README.md']' returned non-zero exit status 1
[simleo@simleo-U36SD:pydoop-features (logging)]$ head err out
==> err <==
Exception in thread "main" loci.formats.FormatException: Invalid XML description
	at loci.formats.in.LIFReader.initFile(LIFReader.java:417)
	at loci.formats.FormatReader.setId(FormatReader.java:1426)
	at loci.formats.ImageReader.setId(ImageReader.java:835)
	at it.crs4.features.ImageToAvro.main(ImageToAvro.java:104)
==> out <==
2016-08-31 08:41:03,058 INFO: [loci.formats.ImageReader] LIFReader initializing README.md
2016-08-31 08:41:03,060 INFO: [loci.formats.FormatHandler] Reading header


[simleo@simleo-U36SD:pydoop-features (logging)]$ pyfeatures --stderr err --stdout out calc 37117_small_0.avro 
[simleo@simleo-U36SD:pydoop-features (logging)]$ head err out
==> err <==
writing to /home/simleo/git/simleo/pydoop-features/37117_small_0_features.avro
processing [0, 0, 0]
All done
==> out <==


[simleo@simleo-U36SD:pydoop-features (logging)]$ pyfeatures --stderr err --stdout out calc README.md 
Traceback (most recent call last):
  File "/home/simleo/.local/bin/pyfeatures", line 33, in <module>
    main(sys.argv[1:])
  File "/home/simleo/.local/lib/python2.7/site-packages/pyfeatures/app/main.py", line 77, in main
    args.func(args, extra_argv=extra_argv)
  File "/home/simleo/.local/lib/python2.7/site-packages/pyfeatures/app/calc.py", line 70, in run
    reader = AvroFileReader(fin)
IOError: Error opening file: Incorrect Avro container file magic number
[simleo@simleo-U36SD:pydoop-features (logging)]$ head err out
==> err <==
writing to /home/simleo/git/simleo/pydoop-features/README_features.md
==> out <==
```

The above examples show a number of issues:

 * Java logging to stdout and Python to stderr
 * Different formats in Java and Python (Python actually lost formatting when the redirection was on)
 * Actual error message "lost" to the console in `pyfeatures calc`

With this PR:

 * All logging is sent to stdout. Since all commands write their ouput to files, stdout can be used for the "normal" console output, while exception tracebacks and warnings go to stderr
 * Both the Java and the Python part log in the same format
 * Stream redirection is left to the calling process (i.e., the feature has been removed). See https://github.com/manics/celery-example/pull/1
 * Python logging has been centralized

TODO
----
Currently the logging level is hardwired (to `INFO`) in Java. This should be changed so that`pyfeatures serialize` can pass the specified level down to the subprocess.
